### PR TITLE
Generate attestations in different job

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -119,6 +119,24 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
 
+      - name: Upload release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudflare-utils-release
+          path: cmd/cloudflare-utils/dist/*
+
+  CreateAttestation:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: Release
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Download the release assets
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudflare-utils-release
+
       - uses: actions/attest-build-provenance@v2
         with:
-          subject-checksums: ./cmd/cloudflare-utils/dist/checksums.txt
+          subject-checksums: ./checksums.txt


### PR DESCRIPTION
Generate the attestations in a different job to get around file path limits