### PR TITLE
Swap to using context.Background() for rapid deletes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver",
-    "schedule:earlyMondays",
-    "github>Cyb3r-Jak3/renovate-configs//assign-me.json"
+    "github>Cyb3r-Jak3/renovate-configs//recommend-extended.json",
+    "github>Cyb3r-Jak3/renovate-configs//my-registry.json"
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
 }

--- a/cmd/cloudflare-utils/dns-cleaner.go
+++ b/cmd/cloudflare-utils/dns-cleaner.go
@@ -192,7 +192,7 @@ func DownloadDNS(ctx context.Context, c *cli.Command) error {
 }
 
 // UploadDNS makes the changes to DNS records based on the dns file.
-func UploadDNS(ctx context.Context, c *cli.Command) error {
+func UploadDNS(_ context.Context, c *cli.Command) error {
 	dnsFilePath := c.String(dnsFileFlag)
 	if !common.FileExists(dnsFilePath) {
 		return fmt.Errorf("no DNS file found at '%s'", dnsFilePath)

--- a/cmd/cloudflare-utils/dns-cleaner.go
+++ b/cmd/cloudflare-utils/dns-cleaner.go
@@ -230,7 +230,7 @@ func UploadDNS(ctx context.Context, c *cli.Command) error {
 		fmt.Printf("Dry Run: Would have removed %d records\n", len(toRemove))
 		return nil
 	}
-	removeErrors := RapidDNSDelete(ctx, zoneResource, toRemove)
+	removeErrors := RapidDNSDelete(zoneResource, toRemove)
 	errorCount = len(removeErrors)
 
 	if errorCount == 0 {

--- a/cmd/cloudflare-utils/dns-purge.go
+++ b/cmd/cloudflare-utils/dns-purge.go
@@ -63,7 +63,7 @@ func DNSPurge(ctx context.Context, c *cli.Command) error {
 		return nil
 	}
 
-	errors := RapidDNSDelete(ctx, zoneResource, records)
+	errors := RapidDNSDelete(zoneResource, records)
 	errorCount := len(errors)
 
 	if errorCount == 0 {

--- a/cmd/cloudflare-utils/prune-deployments.go
+++ b/cmd/cloudflare-utils/prune-deployments.go
@@ -18,7 +18,6 @@ const (
 
 type pruneDeploymentOptions struct {
 	c                   *cli.Command
-	ctx                 context.Context
 	ResourceContainer   *cloudflare.ResourceContainer
 	ProjectName         string
 	SelectedDeployments []cloudflare.PagesProjectDeployment
@@ -74,7 +73,7 @@ func buildPruneDeploymentsCommand() *cli.Command {
 }
 
 // PruneDeploymentsScreen is the entry point for the prune-deployments command.
-// It handles parsing the CLI arguments, and then calls PruneDeploymentsRoot.
+// It handles parsing the CLI arguments and then calls PruneDeploymentsRoot.
 func PruneDeploymentsScreen(ctx context.Context, c *cli.Command) error {
 	logger.Info("Staring prune deployments")
 	if err := CheckAPITokenPermission(ctx, PagesWrite); err != nil {

--- a/cmd/cloudflare-utils/utils.go
+++ b/cmd/cloudflare-utils/utils.go
@@ -109,13 +109,13 @@ func DeploymentsPaginate(params PagesDeploymentPaginationOptions) ([]cloudflare.
 
 // RapidDNSDelete is a helper function to delete DNS records quickly.
 // Uses a pool of goroutines to delete records in parallel.
-func RapidDNSDelete(ctx context.Context, rc *cloudflare.ResourceContainer, dnsRecords []cloudflare.DNSRecord) map[string]error {
+func RapidDNSDelete(rc *cloudflare.ResourceContainer, dnsRecords []cloudflare.DNSRecord) map[string]error {
 	p := pool.NewWithResults[bool]()
 	results := make(map[string]error)
 	p.WithMaxGoroutines(maxGoRoutines)
 	for _, dnsRecord := range dnsRecords {
 		p.Go(func() bool {
-			err := APIClient.DeleteDNSRecord(ctx, rc, dnsRecord.ID)
+			err := APIClient.DeleteDNSRecord(context.Background(), rc, dnsRecord.ID)
 			if err != nil {
 				logger.WithError(err).Warningf("Error deleting DNS record: %s\n", dnsRecord.ID)
 				results[dnsRecord.ID] = err
@@ -141,7 +141,7 @@ func RapidPagesDeploymentDelete(options pruneDeploymentOptions) map[string]error
 	p.WithMaxGoroutines(goRoutines)
 	for _, deployment := range options.SelectedDeployments {
 		p.Go(func() bool {
-			err := APIClient.DeletePagesDeployment(options.ctx, options.ResourceContainer, cloudflare.DeletePagesDeploymentParams{
+			err := APIClient.DeletePagesDeployment(context.Background(), options.ResourceContainer, cloudflare.DeletePagesDeploymentParams{
 				ProjectName:  options.ProjectName,
 				DeploymentID: deployment.ID,
 				Force:        true,


### PR DESCRIPTION
Should fix #179 
Removes passing context to the delete functions, as they don't seem to like it.