### PR TITLE
Add back lots of deployment rate limiting

### DIFF
--- a/cmd/cloudflare-utils/flags.go
+++ b/cmd/cloudflare-utils/flags.go
@@ -11,4 +11,5 @@ const (
 	projectNameFlag = "project"
 	dryRunFlag      = "dry-run"
 	forceFlag       = "force"
+	rateLimitFlag   = "rate-limit"
 )

--- a/cmd/cloudflare-utils/main.go
+++ b/cmd/cloudflare-utils/main.go
@@ -143,7 +143,7 @@ func setup(ctx context.Context, c *cli.Command) (context context.Context, err er
 	}
 
 	rateLimit := c.Float(rateLimitFlag)
-	if c.Bool(lotsOfDeploymentsFlag) {
+	if c.Bool(lotsOfDeploymentsFlag) && rateLimit == 4 {
 		rateLimit = 3
 	}
 	cfClientOptions := []cloudflare.Option{

--- a/cmd/cloudflare-utils/main.go
+++ b/cmd/cloudflare-utils/main.go
@@ -84,7 +84,7 @@ func buildApp() *cli.Command {
 				Sources: cli.EnvVars("CLOUDFLARE_ACCOUNT_ID"),
 			},
 			&cli.FloatFlag{
-				Name:   "rate-limit",
+				Name:   rateLimitFlag,
 				Usage:  "Rate limit for API calls.\nDefault is 4 which matches the Cloudflare API limit of 1200 calls per 5 minutes",
 				Value:  4,
 				Hidden: true,
@@ -142,7 +142,10 @@ func setup(ctx context.Context, c *cli.Command) (context context.Context, err er
 		return ctx, errors.New("no authentication method detected")
 	}
 
-	rateLimit := c.Float("rate-limit")
+	rateLimit := c.Float(rateLimitFlag)
+	if c.Bool(lotsOfDeploymentsFlag) {
+		rateLimit = 3
+	}
 	cfClientOptions := []cloudflare.Option{
 		cloudflare.UsingRateLimit(rateLimit),
 		cloudflare.UserAgent(fmt.Sprintf("cloudflare-utils/%s", version)),


### PR DESCRIPTION
Brings back decreasing the rate limit to 3/req/s if `lots-of-deployments` flag is set and rate limit has not been changed.