### PR TITLE
Migrate codecov action

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -73,7 +73,7 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           use_oidc: true
-          report_type: test_result
+          report_type: test_results
 
   Snapshot:
     if: ${{ startsWith(github.ref, 'refs/tags/v') == false && github.ref != 'refs/heads/main' }}

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -19,6 +19,8 @@ on:
       - '**.go'
       - 'go.sum'
       - 'go.mod'
+      - .github/workflows/golang.yml
+      - '.goreleaser.yml'
 
 permissions:
   security-events: write

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -68,9 +68,10 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           use_oidc: true
+          report_type: test_result
 
   Snapshot:
     if: ${{ startsWith(github.ref, 'refs/tags/v') == false && github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
`codecov/test-results-action` → `codecov/codecov-action` as the test results one is being deprecated